### PR TITLE
Readme - Quick Installation using GitHub template repository instead of forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,6 @@
 <img src="https://raw.githubusercontent.com/abhinavs/moonwalk/master/_screenshots/lighthouse-report.png" />
 
 ## Quick Installation
-### GH Pages + Local Development
-1. Go to [this](https://github.com/Zo-Bro-23/moonwalk-template) template repository and click "Use this template" to create a boilerplate repo.
-2. Wait a couple of minutes for the GitHub Actions workflow to finish running.
-3. Go to `Settings` and enable GitHub Pages to deploy from the `gh-pages` branch.
-4. Your site should be up and running!
-5. Next, for local development, fork *your* website repository (created from the template above).
-6. Make sure Jekyll and Ruby are up-to-date.
-7. Run `bundle install` to install all necessary gems.
-8. Run `bundle exec jekyll serve`.
-9. Your development site should be up and running!
-10. For customizing your website, follow the instructions [here](https://github.com/Zo-Bro-23/moonwalk-template#customization)!
-
-### Local Only
 1. [Fork this repository](https://github.com/abhinavs/moonwalk/fork).
 2. `cd moonwalk`
 3. `bin/bootstrap`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 <img src="https://raw.githubusercontent.com/abhinavs/moonwalk/master/_screenshots/lighthouse-report.png" />
 
 ## Quick Installation
+*Instructions for GitHub Pages available [here](github_pages.md)*
 ### Initial Setup
 1. [Fork this repository](https://github.com/abhinavs/moonwalk/fork).
 2. `cd moonwalk`

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@
 9. Your development site should be up and running!
 10. For customizing your website, follow the instructions [here](https://github.com/Zo-Bro-23/moonwalk-template#customization)!
 
-## Local Only
-### Initial Setup
+### Local Only
+#### Initial Setup
 1. [Fork this repository](https://github.com/abhinavs/moonwalk/fork).
 2. `cd moonwalk`
 3. `bin/bootstrap`
@@ -47,7 +47,7 @@
 
 If you are installing Moonwalk on Windows, please note that you might have to use Ruby 3.0.x instead of Ruby 3.1.x - you can see Windows specific installation instructions [here](https://github.com/abhinavs/moonwalk/blob/master/moonwalk_on_windows.md)
 
-### Starting Server
+#### Starting Server
 `bin/start` - development server will start at http://127.0.0.1:4000
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@
 <img src="https://raw.githubusercontent.com/abhinavs/moonwalk/master/_screenshots/lighthouse-report.png" />
 
 ## Quick Installation
+### GH Pages + Local Development
+1. Go to [this](https://github.com/Zo-Bro-23/moonwalk-template) template repository and click "Use this template" to create a boilerplate repo.
+2. Wait a couple of minutes for the GitHub Actions workflow to finish running.
+3. Go to `Settings` and enable GitHub Pages to deploy from the `gh-pages` branch.
+4. Your site should be up and running!
+5. Next, for local development, fork *your* website repository (created from the template above).
+6. Make sure Jekyll and Ruby are up-to-date.
+7. Run `bundle install` to install all necessary gems.
+8. Run `bundle exec jekyll serve`.
+9. Your development site should be up and running!
+10. For customizing your website, follow the instructions [here](https://github.com/Zo-Bro-23/moonwalk-template#customization)!
+
+## Local Only
+### Initial Setup
 1. [Fork this repository](https://github.com/abhinavs/moonwalk/fork).
 2. `cd moonwalk`
 3. `bin/bootstrap`
@@ -33,7 +47,7 @@
 
 If you are installing Moonwalk on Windows, please note that you might have to use Ruby 3.0.x instead of Ruby 3.1.x - you can see Windows specific installation instructions [here](https://github.com/abhinavs/moonwalk/blob/master/moonwalk_on_windows.md)
 
-## Starting Server
+### Starting Server
 `bin/start` - development server will start at http://127.0.0.1:4000
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -26,20 +26,7 @@
 <img src="https://raw.githubusercontent.com/abhinavs/moonwalk/master/_screenshots/lighthouse-report.png" />
 
 ## Quick Installation
-### GH Pages + Local Development
-1. Go to [this](https://github.com/Zo-Bro-23/moonwalk-template) template repository and click "Use this template" to create a boilerplate repo.
-2. Wait a couple of minutes for the GitHub Actions workflow to finish running.
-3. Go to `Settings` and enable GitHub Pages to deploy from the `gh-pages` branch.
-4. Your site should be up and running!
-5. Next, for local development, fork *your* website repository (created from the template above).
-6. Make sure Jekyll and Ruby are up-to-date.
-7. Run `bundle install` to install all necessary gems.
-8. Run `bundle exec jekyll serve`.
-9. Your development site should be up and running!
-10. For customizing your website, follow the instructions [here](https://github.com/Zo-Bro-23/moonwalk-template#customization)!
-
-### Local Only
-#### Initial Setup
+### Initial Setup
 1. [Fork this repository](https://github.com/abhinavs/moonwalk/fork).
 2. `cd moonwalk`
 3. `bin/bootstrap`
@@ -47,7 +34,7 @@
 
 If you are installing Moonwalk on Windows, please note that you might have to use Ruby 3.0.x instead of Ruby 3.1.x - you can see Windows specific installation instructions [here](https://github.com/abhinavs/moonwalk/blob/master/moonwalk_on_windows.md)
 
-#### Starting Server
+### Starting Server
 `bin/start` - development server will start at http://127.0.0.1:4000
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@
 <img src="https://raw.githubusercontent.com/abhinavs/moonwalk/master/_screenshots/lighthouse-report.png" />
 
 ## Quick Installation
+### GH Pages + Local Development
+1. Go to [this](https://github.com/Zo-Bro-23/moonwalk-template) template repository and click "Use this template" to create a boilerplate repo.
+2. Wait a couple of minutes for the GitHub Actions workflow to finish running.
+3. Go to `Settings` and enable GitHub Pages to deploy from the `gh-pages` branch.
+4. Your site should be up and running!
+5. Next, for local development, fork *your* website repository (created from the template above).
+6. Make sure Jekyll and Ruby are up-to-date.
+7. Run `bundle install` to install all necessary gems.
+8. Run `bundle exec jekyll serve`.
+9. Your development site should be up and running!
+10. For customizing your website, follow the instructions [here](https://github.com/Zo-Bro-23/moonwalk-template#customization)!
+
+### Local Only
 1. [Fork this repository](https://github.com/abhinavs/moonwalk/fork).
 2. `cd moonwalk`
 3. `bin/bootstrap`

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,14 +15,14 @@
   {% feed_meta %}
 
   <!-- Favicon -->
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicon/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon/favicon-16x16.png">
-  <link rel="manifest" href="/assets/images/favicon/site.webmanifest">
-  <link rel="mask-icon" href="/assets/images/favicon/safari-pinned-tab.svg" color="#5bbad5">
-  <link rel="shortcut icon" href="/assets/images/favicon/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/images/favicon/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/images/favicon/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon/favicon-16x16.png">
+  <link rel="manifest" href="assets/images/favicon/site.webmanifest">
+  <link rel="mask-icon" href="assets/images/favicon/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="shortcut icon" href="assets/images/favicon/favicon.ico">
   <meta name="msapplication-TileColor" content="#00aba9">
-  <meta name="msapplication-config" content="/assets/images/favicon/browserconfig.xml">
+  <meta name="msapplication-config" content="assets/images/favicon/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
   <!-- Favicon -->
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,14 +15,14 @@
   {% feed_meta %}
 
   <!-- Favicon -->
-  <link rel="apple-touch-icon" sizes="180x180" href="assets/images/favicon/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="assets/images/favicon/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon/favicon-16x16.png">
-  <link rel="manifest" href="assets/images/favicon/site.webmanifest">
-  <link rel="mask-icon" href="assets/images/favicon/safari-pinned-tab.svg" color="#5bbad5">
-  <link rel="shortcut icon" href="assets/images/favicon/favicon.ico">
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicon/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon/favicon-16x16.png">
+  <link rel="manifest" href="/assets/images/favicon/site.webmanifest">
+  <link rel="mask-icon" href="/assets/images/favicon/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="shortcut icon" href="/assets/images/favicon/favicon.ico">
   <meta name="msapplication-TileColor" content="#00aba9">
-  <meta name="msapplication-config" content="assets/images/favicon/browserconfig.xml">
+  <meta name="msapplication-config" content="/assets/images/favicon/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
   <!-- Favicon -->
 

--- a/github_pages.md
+++ b/github_pages.md
@@ -1,15 +1,11 @@
 ## Use Moonwalk with Github Pages
-
-You can use Github Pages for deploying moonwalk for free.
-
-> If you are deploying Moonwalk on Github Pages, I recommend forking Moonwalk and change the dependency (in `moonwalk.gemspec` & `_config.yml`) from `jekyll-soopr-seo-tag` to `jekyll-seo-tag` - Github Pages only allow a specific list of gems to be installed.
-
-
-### GitHub Pages installation
-
-If you want to use this theme for your Jekyll's site deployed on [GitHub Pages](https://pages.github.com/), follow the instructions on [this page](https://docs.github.com/en/github/working-with-github-pages/adding-a-theme-to-your-github-pages-site-using-jekyll#adding-a-theme).
-
-#### Please Note
-The default branch that Github pages uses to build and deploy the site is gh-pages branch (and not the master/main branch). To deploy master branch instead, you can change the settings as follows:
-
-FORKED_REPO > Settings > Pages > Source > select(Branch=Master)
+1. Go to [this](https://github.com/Zo-Bro-23/moonwalk-template) template repository and click "Use this template" to create a boilerplate repo.
+2. Wait a couple of minutes for the GitHub Actions workflow to finish running.
+3. Go to `Settings` and enable GitHub Pages to deploy from the `gh-pages` branch.
+4. Your site should be up and running!
+5. Next, for local development, fork *your* website repository (created from the template above).
+6. Make sure Jekyll and Ruby are up-to-date.
+7. Run `bundle install` to install all necessary gems.
+8. Run `bundle exec jekyll serve`.
+9. Your development site should be up and running!
+10. For customizing your website, follow the instructions [here](https://github.com/Zo-Bro-23/moonwalk-template#customization)!


### PR DESCRIPTION
I made a GitHub template repository for moonwalk ([here](https://github.com/Zo-Bro-23/moonwalk-template)) which makes quick start a lot easier if you're working mainly from GH Pages instead of locally. This PR updates the readme for better getting started instructions regarding this.