### PR TITLE
Fix: Scroll bounce white when in dark mode

### DIFF
--- a/_sass/moonwalk.scss
+++ b/_sass/moonwalk.scss
@@ -63,16 +63,18 @@ img {
   display: block;
   margin: 0 auto;
 }
-html {
-    --bg: #FFF;
-    --bg-secondary: #f3f4f6;
-    --headings: #1e293b;
-    --text: #374151;
-    --text-secondary: #6b7280;
-    --links: #6366f1;
-    --highlight: #FFECB2; // light yellow
-    --code-text: #9D174D;
-    --share-text: #999;
+@mixin light-appearance {
+  html, body {
+      --bg: #FFF;
+      --bg-secondary: #f3f4f6;
+      --headings: #1e293b;
+      --text: #374151;
+      --text-secondary: #6b7280;
+      --links: #6366f1;
+      --highlight: #FFECB2; // light yellow
+      --code-text: #9D174D;
+      --share-text: #999;
+  }
 }
 // -------------- THEME SWITCHER -------------- //
 @mixin dark-appearance {

--- a/_sass/moonwalk.scss
+++ b/_sass/moonwalk.scss
@@ -88,11 +88,17 @@ html {
       --share-text: #C4C4C4;
   };
 }
+
 html[data-theme="dark"] { @include dark-appearance; }
+html[data-theme="light"] { @include light-appearance; }
 
 @media (prefers-color-scheme: dark) {
   body[data-theme="auto"] { @include dark-appearance; }
 }
+@media (prefers-color-scheme: light) {
+  body[data-theme="auto"] { @include light-appearance; }
+}
+  
 // -------------------------------------------- //
 
 html, body {


### PR DESCRIPTION
There is a weird issue where when the site is in dark mode, the scroll bounce will be white and not the background color of the site. I have adjusted the sass to make light mode a mixin and load specifically light or dark mode based on the setting. 
<img width="1354" alt="Screenshot 2023-07-19 at 7 30 04 PM" src="https://github.com/abhinavs/moonwalk/assets/12686250/65640467-a809-44d6-b10d-c7f946d0f489">


For some reason the background-color for the html tags was still being set to #FFF 
<img width="322" alt="Screenshot 2023-07-19 at 7 31 05 PM" src="https://github.com/abhinavs/moonwalk/assets/12686250/816a0639-d350-4b25-857d-c5c8c8055347">


This PR fixes this problem and continues to work in both light and dark mode